### PR TITLE
Added support for a port number in the AFHTTPClient baseURL.

### DIFF
--- a/JGAFImageCache.m
+++ b/JGAFImageCache.m
@@ -154,7 +154,7 @@
 - (void)loadRemoteImageForURL:(NSString *)url key:(NSString *)key retryCount:(NSInteger)retryCount completion:(void (^)(NSImage *image))completion {
 #endif
     NSURL *imageURL = [NSURL URLWithString:url];
-    NSString *baseURL = [NSString stringWithFormat:@"%@://%@", imageURL.scheme, imageURL.host];
+    NSString *baseURL = [NSString stringWithFormat:@"%@://%@:%@", imageURL.scheme, imageURL.host, imageURL.port];
     NSString *imagePath = [[self class] escapedPathForURL:imageURL];
     AFHTTPClient *httpClient = [self httpClientForBaseURL:baseURL];
     [httpClient


### PR DESCRIPTION
The current loadRemoteImageForURL method does not define a port number and therefore every image is requested over port 80. This commit adds support for a port number.

By the way, NSURL docs state that [imageURL port] should return nil in case the port does not conform to RFC 1808. I tested URLs with and without port numbers but both seem to work correctly. I suppose the AFHTTPClient handles both cases. 
